### PR TITLE
Add install dependencies, rename python3-ldap to ldap3. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Possible symlink to dev version of python3-ldap dependency
+# Possible symlink to dev version of ldap3 dependency
 activedirectory/ldap3/
 
 # Byte-compiled / optimized / DLL files

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install:
 	python setup.py install
 
 uninstall:
-	pip uninstall python3-ldap
+	pip uninstall ldap3
 
 pep8:
 	py.test --pep8 -m pep8
@@ -26,7 +26,7 @@ coverage:
 
 travis:
 	pip install coveralls
-	coverage run --source=python3-ldap runtests.py
+	coverage run --source=ldap3 runtests.py
 
 pypi:
 	python setup.py check --restructuredtext --strict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 coverage
-python3-ldap>=0.9.5.2
+ldap3>=0.9.5.2
 six

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet',
     ],
-    setup_requires=['six', 'tox', 'python3-ldap'],  # ,'nosexcover'],
+    setup_requires=['six', 'tox', 'ldap3'],  # ,'nosexcover'],
+    install_requires=['six', 'ldap3'],
     tests_require=test_requirements,  # autopep8 removed because it does not install on python2.5
     test_suite=test_suite,
     cmdclass={'test': Tox},

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps=
     sphinx
     six
     docutils
-    python3-ldap
+    ldap3
 commands=
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
@@ -25,7 +25,7 @@ deps=
     pytest-cov
     pytest-xdist
     six>=1.7.2
-    python3-ldap
+    ldap3
     virtualenv>=1.11.2
 
 commands=


### PR DESCRIPTION
The install dependencies are needed for "pip install activedirectory" to succeed on a virgin system.
Upstream has renamed python3-ldap to ldap3.
